### PR TITLE
Updated to Exiled 3.0.0

### DIFF
--- a/SCPSwap/Commands/Scpswap/Scpswap.cs
+++ b/SCPSwap/Commands/Scpswap/Scpswap.cs
@@ -5,6 +5,7 @@ using MEC;
 using System;
 using System.Linq;
 
+
 namespace ScpSwap.Commands.ScpSwapCommand
 {
     [CommandHandler(typeof(ClientCommandHandler))]
@@ -69,6 +70,11 @@ namespace ScpSwap.Commands.ScpSwapCommand
 				response = "That SCP is blacklisted.";
 				return false;
 			}
+			if(!EventHandlers.plugin.Config.CanZombiesSwap && ply.Role == RoleType.Scp0492)
+            {
+				response = "Zombies cannot swap with scp's.";
+				return false;
+            }
 
 			if (ply.Role == role)
 			{
@@ -85,7 +91,7 @@ namespace ScpSwap.Commands.ScpSwapCommand
 			}
 			if (EventHandlers.plugin.Config.SwapAllowNewScps)
 			{
-				ply.ReferenceHub.characterClassManager.SetPlayersClass(role, ply.ReferenceHub.gameObject);
+				ply.ReferenceHub.characterClassManager.SetPlayersClass(role, ply.ReferenceHub.gameObject, CharacterClassManager.SpawnReason.ForceClass);
 				response = "Could not find a player to swap with, you have been made the specified SCP.";
 				return false;
 			}

--- a/SCPSwap/Config.cs
+++ b/SCPSwap/Config.cs
@@ -14,5 +14,6 @@ namespace ScpSwap
         public ushort StartMessageTime { get; set; } = 15;
         public string DisplayMessageText { get; set; } = "<color=yellow><b>Did you know you can swap classes with other SCP's?</b></color> Simply type <color=orange>.scpswap (role number)</color> in your in-game console (not RA) to swap!";
         public List<int> SwapBlacklist { get; private set; } = new List<int>() { 10 };
+        public bool CanZombiesSwap { get; set; } = false;
     }
 }

--- a/SCPSwap/EventHandlers.cs
+++ b/SCPSwap/EventHandlers.cs
@@ -130,10 +130,7 @@ namespace ScpSwap
 			allowSwaps = false;
 		}
 
-		public void OnConsoleCommand(SendingConsoleCommandEventArgs ev)
-		{
-
-		}
+		
 
 		public void BroadcastMessage()
 		{

--- a/SCPSwap/SCPSwap.cs
+++ b/SCPSwap/SCPSwap.cs
@@ -8,9 +8,9 @@ namespace ScpSwap
 	{
 		public EventHandlers Handler { get; private set; }
 		public override string Name => nameof(ScpSwap);
-		public override string Author => "Originally written by Cyanox, modifications by KoukoCocoa & Thomasjosif";
-		public override Version Version { get; } = new Version(1, 3, 2);
-		public override Version RequiredExiledVersion { get; } = new Version(2, 1, 29, 0);
+		public override string Author => "Originally written by Cyanox, modifications by KoukoCocoa & Thomasjosif, updated to Exiled 3.0.0 by Redforce04";
+		public override Version Version { get; } = new Version(1, 4, 0);
+		public override Version RequiredExiledVersion { get; } = new Version(3, 0, 0);
 
 		public ScpSwap() { }
 
@@ -21,7 +21,6 @@ namespace ScpSwap
 			Handlers.Server.RoundStarted += Handler.OnRoundStart;
 			Handlers.Server.RoundEnded += Handler.OnRoundEnd;
 			Handlers.Server.RestartingRound += Handler.OnRoundRestart;
-			Handlers.Server.SendingConsoleCommand += Handler.OnConsoleCommand;
 		}
 
 		public override void OnDisabled()
@@ -30,7 +29,6 @@ namespace ScpSwap
 			Handlers.Server.RoundStarted -= Handler.OnRoundStart;
 			Handlers.Server.RoundEnded -= Handler.OnRoundEnd;
 			Handlers.Server.RestartingRound -= Handler.OnRoundRestart;
-			Handlers.Server.SendingConsoleCommand -= Handler.OnConsoleCommand;
 			Handler = null;
 		}
 

--- a/SCPSwap/SCPSwap.csproj
+++ b/SCPSwap/SCPSwap.csproj
@@ -32,43 +32,46 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\EXILED_REFERENCES\0Harmony.dll</HintPath>
+      <HintPath>..\..\..\..\..\Desktop\SCP Plugin\EXILED\Plugins\dependencies\0Harmony.dll</HintPath>
     </Reference>
-    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\EXILED_REFERENCES\Assembly-CSharp.dll</HintPath>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>..\..\..\..\..\Desktop\SCP Plugin\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\..\EXILED_REFERENCES\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>..\..\..\..\..\Desktop\SCP\SCPSL_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
-    <Reference Include="CommandSystem.Core, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\EXILED_REFERENCES\CommandSystem.Core.dll</HintPath>
+    <Reference Include="Assembly-CSharp-Publicized %286%29">
+      <HintPath>..\..\..\..\..\Desktop\SCP Plugin\Assembly-CSharp-Publicized (6).dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.API, Version=2.1.29.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.1.29\lib\net472\Exiled.API.dll</HintPath>
+    <Reference Include="CommandSystem.Core">
+      <HintPath>..\..\..\..\..\Desktop\SCP\SCPSL_Data\Managed\CommandSystem.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.Bootstrap, Version=2.1.29.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.1.29\lib\net472\Exiled.Bootstrap.dll</HintPath>
+    <Reference Include="Exiled.API">
+      <HintPath>..\..\..\..\..\Desktop\SCP Plugin\EXILED\Plugins\dependencies\Exiled.API.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.Events, Version=2.1.29.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.1.29\lib\net472\Exiled.Events.dll</HintPath>
+    <Reference Include="Exiled.CreditTags">
+      <HintPath>..\..\..\..\..\Desktop\SCP Plugin\EXILED\Plugins\Exiled.CreditTags.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.Loader, Version=2.1.29.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.1.29\lib\net472\Exiled.Loader.dll</HintPath>
+    <Reference Include="Exiled.CustomItems">
+      <HintPath>..\..\..\..\..\Desktop\SCP Plugin\EXILED\Plugins\Exiled.CustomItems.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.Permissions, Version=2.1.29.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.1.29\lib\net472\Exiled.Permissions.dll</HintPath>
+    <Reference Include="Exiled.Events">
+      <HintPath>..\..\..\..\..\Desktop\SCP Plugin\EXILED\Plugins\Exiled.Events.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.Updater, Version=3.0.3.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\EXILED.2.1.29\lib\net472\Exiled.Updater.dll</HintPath>
+    <Reference Include="Exiled.Loader">
+      <HintPath>..\..\..\..\..\Desktop\SCP Plugin\EXILED\Exiled.Loader.dll</HintPath>
+    </Reference>
+    <Reference Include="Exiled.Permissions">
+      <HintPath>..\..\..\..\..\Desktop\SCP Plugin\EXILED\Plugins\Exiled.Permissions.dll</HintPath>
+    </Reference>
+    <Reference Include="Exiled.Updater">
+      <HintPath>..\..\..\..\..\Desktop\SCP Plugin\EXILED\Plugins\Exiled.Updater.dll</HintPath>
     </Reference>
     <Reference Include="Mirror">
-      <HintPath>..\..\EXILED_REFERENCES\Mirror.dll</HintPath>
+      <HintPath>..\..\..\..\..\Desktop\SCP\SCPSL_Data\Managed\Mirror.dll</HintPath>
     </Reference>
-    <Reference Include="NorthwoodLib, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\EXILED_REFERENCES\NorthwoodLib.dll</HintPath>
+    <Reference Include="NorthwoodLib">
+      <HintPath>..\..\..\..\..\Desktop\SCP\SCPSL_Data\Managed\NorthwoodLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -79,10 +82,10 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\EXILED_REFERENCES\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\..\Desktop\SCP\SCPSL_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\EXILED_REFERENCES\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\Desktop\SCP\SCPSL_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Updates plugin to Exiled 3.0.0, and adds a config option to prevent zombies from using scpswap. This is added because blacklisting scp's will only prevent other scp's from swapping too the blacklisted scp, and the blacklisted scp can still swap to other scps. This can be abused and players can be killed, revived by 049, and swap within the initial scpswap time. This option will prevent that.